### PR TITLE
Fix README npm instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The site doesn't do very well on mobile, so any contribution there are welcome. 
 
 ```
 git clone https://github.com/nindalf/arewefastyet
-cd arewefastyet/
+cd arewefastyet/site
 npm install && npm run dev
 ```
 


### PR DESCRIPTION
Just taking a look at the site (might have a few more PR ideas) and noticed the README's instructions currently lead to a no-op call of `npm install`, users need to go into /site for it to find the actual `package.json`.