### PR TITLE
Fix react key warning on Line components.

### DIFF
--- a/site/components/linechart.tsx
+++ b/site/components/linechart.tsx
@@ -108,7 +108,8 @@ export class LineChartX extends Component<LineChartXProps> {
                 }} />
                 <Legend align='right' />
                 {this.compileTimeDataKeys().map(([cm, pm, system]) => {
-                    return <Line type="monotone" dataKey={cm + ',' + pm + ',' + system} stroke={lineColours[cm + ',' + system]} strokeWidth={strokeWidthMap[system]} />;
+                    const key = `${cm},${pm},${system}`;
+                    return <Line type="monotone" dataKey={key} stroke={lineColours[cm + ',' + system]} strokeWidth={strokeWidthMap[system]} key={key} />;
                 })
                 }
 


### PR DESCRIPTION
`dataKey` already had a natural key, so let's pull it out and use it for both to resolve the warning.