### PR TITLE
Improve tooltip consistency, clarity, and look.

### DIFF
--- a/site/components/linechart.tsx
+++ b/site/components/linechart.tsx
@@ -74,7 +74,7 @@ export class LineChartX extends Component<LineChartXProps> {
     perfDelta(key: string, currentVersion: string) {
         let compile_times = this.props.chartData.compile_times;
         if (currentVersion === compile_times[0]["version"]) {
-            return " (0%)";
+            return 0;
         }
         let i = 0;
         let prev = compile_times[i];
@@ -86,7 +86,7 @@ export class LineChartX extends Component<LineChartXProps> {
         }
         let currentVal = current[key] as number;
         const previousVal = prev[key] as number;
-        return " (" + (((previousVal-currentVal)/previousVal)*100).toString().substr(0, 4) + "%)";
+        return (previousVal - currentVal)/previousVal * 100;
     }
 
 
@@ -101,11 +101,15 @@ export class LineChartX extends Component<LineChartXProps> {
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="version"></XAxis>
                 <YAxis><Label value="Time (seconds)" position='left' angle={-90} /></YAxis>
-                <Tooltip formatter={(value, name, props) => {
-                    const currentVersion = props.payload.version;
-                    const delta = this.perfDelta(name, currentVersion);
-                    return value + delta;
-                }} />
+                <Tooltip
+                   labelFormatter={e => `v${e}`}
+                   separator={': '}
+                   formatter={(value, name, props) => {
+                     const currentVersion = props.payload.version;
+                     const delta = this.perfDelta(name, currentVersion);
+                     return `${value.toFixed(2)}s (${delta.toFixed(2)}%)`;
+                   }}
+                />
                 <Legend align='right' />
                 {this.compileTimeDataKeys().map(([cm, pm, system]) => {
                     const key = `${cm},${pm},${system}`;


### PR DESCRIPTION
- prepend a 'v' to the version number headings to make it clearer what
  they represent, as someone not familiar with rust may not immediately
  infer that '1.42' on its own is a version number
- changed perfDelta to always return a number, rather than a formatted
  string, and put the string formatting in the tooltip's `formatter`
  function, a little bit more cleanly shown with string template
- also use toFixed for delta+value numbers rather than string manip to
  consistently round off to 2 decimals, where before there were odd
  artifacts like "(12.%)" sometimes
- changed the separator to remove the leading space, because a string
  like "key : value" is less common convention than "key: value".

before:
![image](https://user-images.githubusercontent.com/435879/115276519-1e4fe300-a111-11eb-8f87-d9c39eec61ef.png)
after:
![image](https://user-images.githubusercontent.com/435879/115276455-09734f80-a111-11eb-8939-20c95a6efcc2.png)