### PR TITLE
Improve y-axis label placement.

### DIFF
--- a/site/components/linechart.tsx
+++ b/site/components/linechart.tsx
@@ -100,7 +100,7 @@ export class LineChartX extends Component<LineChartXProps> {
             >
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="version"></XAxis>
-                <YAxis><Label value="Time (seconds)" position='insideBottomLeft' /> </YAxis>
+                <YAxis><Label value="Time (seconds)" position='left' angle={-90} /></YAxis>
                 <Tooltip formatter={(value, name, props) => {
                     const currentVersion = props.payload.version;
                     const delta = this.perfDelta(name, currentVersion);
@@ -130,7 +130,7 @@ export class LineChartX extends Component<LineChartXProps> {
             >
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="version" ></XAxis>
-                <YAxis><Label value="Size (MB)" position='insideBottomLeft' /> </YAxis>
+                <YAxis><Label value="Size (MB)" position='left' angle={-90} /> </YAxis>
                 <Tooltip />
                 <Legend align='right' />
                 <Line type="monotone" dataKey="Debug" stroke="#8884d8" />


### PR DESCRIPTION
It's awkwardly rendering just inside the bottom left corner of the
graph, so let's place it outside and rotate it so it fits in the
margins. It's still a little odd, but it's better.

before:
![image](https://user-images.githubusercontent.com/435879/115275974-79cda100-a110-11eb-8d94-cadbe608d79a.png)
after:
![image](https://user-images.githubusercontent.com/435879/115275934-6d494880-a110-11eb-8d1a-f1621262434a.png)
(note: the line-colours in the after differ a little, due to some styling cruft on my branch)