### PR TITLE
Use spaces in data keys for nicer legend labels.

### DIFF
--- a/site/components/linechart.tsx
+++ b/site/components/linechart.tsx
@@ -15,20 +15,20 @@ export interface LineChartXProps {
 }
 
 const lineColours: Record<string, string> = {
-    'Check,2 cores': '#ff94a8',
-    'Check,4 cores': '#fa738c',
-    'Check,8 cores': '#fc3d60',
-    'Check,16 cores': '#f71640',
+    'Check, 2 cores': '#ff94a8',
+    'Check, 4 cores': '#fa738c',
+    'Check, 8 cores': '#fc3d60',
+    'Check, 16 cores': '#f71640',
 
-    'Debug,2 cores': '#9f95fc',
-    'Debug,4 cores': '#8377f7',
-    'Debug,8 cores': '#6556f5',
-    'Debug,16 cores': '#4a38fc',
+    'Debug, 2 cores': '#9f95fc',
+    'Debug, 4 cores': '#8377f7',
+    'Debug, 8 cores': '#6556f5',
+    'Debug, 16 cores': '#4a38fc',
 
-    'Release,2 cores': '#6cb871',
-    'Release,4 cores': '#4db353',
-    'Release,8 cores': '#2bb534',
-    'Release,16 cores': '#05b511',
+    'Release, 2 cores': '#6cb871',
+    'Release, 4 cores': '#4db353',
+    'Release, 8 cores': '#2bb534',
+    'Release, 16 cores': '#05b511',
 };
 
 const strokeWidthMap: Record<string, number> = {
@@ -112,8 +112,8 @@ export class LineChartX extends Component<LineChartXProps> {
                 />
                 <Legend align='right' />
                 {this.compileTimeDataKeys().map(([cm, pm, system]) => {
-                    const key = `${cm},${pm},${system}`;
-                    return <Line type="monotone" dataKey={key} stroke={lineColours[cm + ',' + system]} strokeWidth={strokeWidthMap[system]} key={key} />;
+                    const key = `${cm}, ${pm}, ${system}`;
+                    return <Line type="monotone" dataKey={key} stroke={lineColours[cm + ', ' + system]} strokeWidth={strokeWidthMap[system]} key={key} />;
                 })
                 }
 

--- a/site/data/chartData.ts
+++ b/site/data/chartData.ts
@@ -38,7 +38,7 @@ function combineCompileTimes(repo_names: Array<string>, profiles: Array<[number,
             const compile_times = profile[repo_name].compile_times;
             Object.entries(compile_times).forEach(([key, timings]) => {
                 const [version, compiler_mode, profile_mode] = key.split(",");
-                const new_key = compiler_mode + "," + profile_mode + "," + system;
+                const new_key = compiler_mode + ", " + profile_mode + ", " + system;
 
                 const average_timing = average(timings);
                 if (!output[version]) {


### PR DESCRIPTION
This is a small change visually, but I think it looks much nicer. It is a bit odd to change the _actual_ key of the data, as opposed to just formatting the key at display time, but I was unable to find a reasonable way to format the key for display without writing a whole new legend component.

I'd definitely understand if you feel this isn't really needed, which is why I pulled it out from the previous look-and-feel PR. :)

with this change:
![image](https://user-images.githubusercontent.com/435879/117071343-fe1d4800-acfc-11eb-9eca-bcffe082fae4.png)

before:
![image](https://user-images.githubusercontent.com/435879/117071519-3886e500-acfd-11eb-9ecd-6b2063277d14.png)